### PR TITLE
Switch all usages of Date.today to Time.zone.today

### DIFF
--- a/app/lib/library.rb
+++ b/app/lib/library.rb
@@ -13,7 +13,7 @@ module Library
     raise OverdueLoanError if borrower.current_overdue_count > 0
 
     book.borrower = borrower
-    book.due_on = Date.today + days
+    book.due_on = Time.zone.today + days
     borrower.books << book
   end
 

--- a/spec/lib/issue_book_spec.rb
+++ b/spec/lib/issue_book_spec.rb
@@ -9,14 +9,14 @@ describe Library do
     it 'should issue the book' do
       Library.issue_book book, borrower, 14
       expect(book.borrower).to eq borrower
-      expect(book.due_on).to eq Date.today + 14
+      expect(book.due_on).to eq Time.zone.today + 14
       expect(book).to be_on_loan
       expect(borrower.books).to include book
     end
 
     it 'should default to a 3 week loan' do
       Library.issue_book book, borrower
-      expect(book.due_on).to eq Date.today + 21
+      expect(book.due_on).to eq Time.zone.today + 21
     end
 
     it 'should not issue more books than a borrower is allowed' do

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -35,7 +35,7 @@ describe Book do
     it 'should be the number of days until due date' do
       pending 'EASY'
       expect(book.days_until_due).to be_nil
-      book.due_on = Date.today + 10
+      book.due_on = Time.zone.today + 10
       expect(book.days_until_due).to eq 10
     end
   end

--- a/spec/models/borrower_spec.rb
+++ b/spec/models/borrower_spec.rb
@@ -28,7 +28,7 @@ describe Borrower do
       pending 'EASY'
       book1 = Book.new due_on: 1.day.ago
       book2 = Book.new due_on: 2.days.ago
-      book3 = Book.new due_on: Date.today
+      book3 = Book.new due_on: Time.zone.today
 
       borrower.books = [book1, book2, book3]
 
@@ -44,7 +44,7 @@ describe Borrower do
       pending 'EASY'
       expect(borrower.current_overdue_count).to eq 0
       borrower.books += build_list :book, 2
-      borrower.books += build_list :book, 2, due_on: (Date.today-1)
+      borrower.books += build_list :book, 2, due_on: (Time.zone.today-1)
       expect(borrower.current_overdue_count).to eq 2
     end
   end


### PR DESCRIPTION
So I happened to be taking a look at this right as midnight rolled around and all my tests started failing again, seems there's some timezone issues with using `Date.today` along with the `ActiveSupport::TimeWithZone` methods like [`#today?`](http://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html#method-i-today-3F).

An alternative that would likely work as well for the purposes of the meetup is to change `config/application.rb:36` to NZST. The tests would then likely work whether implementations use `Date.today` or the `Time.zone` methods. Doing it this way may force students to learn proper time zone handling, naïve implementations of `days_until_due` will be half a day out.
